### PR TITLE
Attempt to productionize imaginary-addrs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,4 +16,8 @@ pub struct Args {
     /// Disable kernel configuration
     #[clap(short, long)]
     pub no_config: bool,
+
+    /// Print debug log
+    #[clap(short, long)]
+    pub verbose: bool,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,4 +12,8 @@ pub struct Args {
     /// The network to operate with
     #[clap(short, long)]
     pub network: Ipv6Net,
+
+    /// Disable kernel configuration
+    #[clap(short, long)]
+    pub no_config: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,38 +21,40 @@ pub fn main() {
     let gateway = args.network.hosts().nth(1).unwrap();
     println!("Selected the following gateway: {}", gateway);
 
-    // Configure the kernel for this interface
-    Command::new("ip")
-        .args(vec!["link", "set", "up", "dev", &tun.name()])
-        .status()
-        .unwrap();
-    Command::new("ip")
-        .args(vec![
-            "-6",
-            "addr",
-            "add",
-            &gateway.to_string(),
-            "dev",
-            &tun.name(),
-        ])
-        .status()
-        .unwrap();
-    Command::new("ip")
-        .args(vec![
-            "-6",
-            "route",
-            "add",
-            format!("{}/{}", gateway.to_string(), args.network.prefix_len()).as_str(),
-            "dev",
-            &tun.name(),
-        ])
-        .status()
-        .unwrap();
-    Command::new("sysctl")
-        .args(vec!["-w", "net.ipv6.conf.all.forwarding=1"])
-        .status()
-        .unwrap();
-    println!("Kernel configuration OK");
+    if !args.no_config {
+        // Configure the kernel for this interface
+        Command::new("ip")
+            .args(vec!["link", "set", "up", "dev", &tun.name()])
+            .status()
+            .unwrap();
+        Command::new("ip")
+            .args(vec![
+                "-6",
+                "addr",
+                "add",
+                &gateway.to_string(),
+                "dev",
+                &tun.name(),
+            ])
+            .status()
+            .unwrap();
+        Command::new("ip")
+            .args(vec![
+                "-6",
+                "route",
+                "add",
+                format!("{}/{}", gateway.to_string(), args.network.prefix_len()).as_str(),
+                "dev",
+                &tun.name(),
+            ])
+            .status()
+            .unwrap();
+        Command::new("sysctl")
+            .args(vec!["-w", "net.ipv6.conf.all.forwarding=1"])
+            .status()
+            .unwrap();
+        println!("Kernel configuration OK");
+    }
 
     // Set up the packet capture
     let mut buf = [0u8; 1500];

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,10 +77,12 @@ pub fn main() {
                     // Parse the source and dest addresses
                     let inbound_source_addr = ipv6_from_octets(&inbound_ip_header.source);
                     let inbound_dest_addr = ipv6_from_octets(&inbound_ip_header.destination);
-                    println!(
-                        "Got ICMPv6 packet from {} destined for {}",
-                        inbound_source_addr, inbound_dest_addr
-                    );
+                    if args.verbose {
+                        println!(
+                            "Got ICMPv6 packet from {} destined for {}",
+                            inbound_source_addr, inbound_dest_addr
+                        );
+                    }
 
                     // Construct a return packet header
                     let outbound_ip_header = etherparse::Ipv6Header {
@@ -126,7 +128,9 @@ pub fn main() {
                     // Send the packet back to the client
                     tun.send(&[packet_prefix, outbound_bytes.as_slice()].concat())
                         .unwrap();
-                    println!("Sent fake timeout packet to {}", inbound_source_addr);
+                    if args.verbose {
+                        println!("Sent fake timeout packet to {}", inbound_source_addr);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR does two things:
1. Adds the flag `--no-config` to disable kernel configuration, relying on the user to do it. This enables running as an unprivileged users with `setcap cap_net_admin=+pe` on the executable instead of running as root.
2. Adds the flag `--verbose` and make the prints only executed when the flag is passed.
